### PR TITLE
fix api example code

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -27,7 +27,7 @@ Since detecting and tracking these images happens locally on the device, this fu
 Request image tracking as a required or optional feature using its feature descriptor and a list of images to track:
 
 ```js
-const img = document.getElementById('img);
+const img = document.getElementById('img');
 // Ensure the image is loaded and ready for use
 const imgBitmap = await createImageBitmap(img);
 


### PR DESCRIPTION
Hello, I found a missign single quartation in an API example code in the explainer page.
![image](https://user-images.githubusercontent.com/11372210/164987152-89e32fad-f185-4662-992c-235b36fcc61d.png)

Then I fix it.
![image](https://user-images.githubusercontent.com/11372210/164987219-2f2777af-567e-437a-aa3f-3014f89aa035.png)
